### PR TITLE
Fixed memory leak reported by the sanitizer in Boost unit test.

### DIFF
--- a/src/test_main.cpp
+++ b/src/test_main.cpp
@@ -1,5 +1,6 @@
+#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE example
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include "io_util_test.h"
 #include "OBJ_Loader_test.h"
 #include "geometry_test.h"


### PR DESCRIPTION
The `BOOST_TEST_DYN_LINK` define adds a main method to the test. See [Boost test linking](https://stackoverflow.com/questions/7781374/boost-test-linking) 